### PR TITLE
Fixing Source FromJSON instance to match ToJSON change

### DIFF
--- a/src/Buchhaltung/Types.hs
+++ b/src/Buchhaltung/Types.hs
@@ -92,7 +92,7 @@ json = A.encodeToLazyText
 instance FromJSON Source where
   parseJSON (Object v) = do
     Source <$>
-      (SFormat <$> v .: "name" <*>  v .: "version")
+      (SFormat <$> v .: "formatName" <*>  v .: "formatVersion")
       <*> v.: "store"
 
 instance ToJSON Source where


### PR DESCRIPTION
The `ToJSON` instance for `Source` was recently changed (490cf8e86ea065451de29f1a20afcee0de72757e). I think the `FromJSON` instance needs a corresponding change.