### PR TITLE
use latest stackage LTS; support & require directory 1.2.7.0+

### DIFF
--- a/src/Buchhaltung/Utils.hs
+++ b/src/Buchhaltung/Utils.hs
@@ -53,11 +53,6 @@ instance Monoid a => Monoid (IO a) where
 #endif
 
   
-doesPathExist :: FilePath -> IO Bool
-doesPathExist = fmap getAny . (a . doesFileExist <> a . doesDirectoryExist)
-  where a = fmap Any 
-
-
 -- * Ported from 'System.IO.Temp' to work with 'MonadBaseControl'
   
 withSystemTempFile template action = liftIO getTemporaryDirectory >>= \tmpDir -> withTempFile tmpDir template action

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,9 +8,5 @@ packages:
 #   - hledger-lib
 #   extra-dep: true
 
-resolver: nightly-2017-01-10
+resolver: lts-8.18
 pvp-bounds: both
-
-
-extra-deps:
-  - regex-tdfa-text-1.0.0.3


### PR DESCRIPTION
This reduces rebuilding from using an old nightly snapshot.
And, it fixes a doesPathExist error with directory, by the
quick fix of requireing directory 1.2.7.0 (released aug 2016) or newer.