### PR TITLE
Fix incompatibilities with aqbanking 5.99.44.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,38 @@
+{ mkDerivation, aeson, ansi-wl-pprint, array, async, base, boxes
+, bytestring, cassava, containers, data-default, Decimal, deepseq
+, directory, edit-distance, file-embed, filepath, formatting
+, hashable, haskeline, hint, hledger, hledger-lib, lens
+, lifted-base, ListLike, megaparsec, MissingH, monad-control, mtl
+, optparse-applicative, parsec, process, regex-compat, regex-tdfa
+, regex-tdfa-text, safe, semigroups, split, stdenv, strict
+, temporary, text, time, transformers, unordered-containers, vector
+, yaml
+}:
+mkDerivation {
+  pname = "buchhaltung";
+  version = "0.0.7";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson ansi-wl-pprint array async base boxes bytestring cassava
+    containers data-default Decimal deepseq directory edit-distance
+    file-embed filepath formatting hashable haskeline hint hledger
+    hledger-lib lens lifted-base ListLike megaparsec MissingH
+    monad-control mtl optparse-applicative parsec process regex-compat
+    regex-tdfa regex-tdfa-text safe semigroups split strict temporary
+    text time transformers unordered-containers vector yaml
+  ];
+  executableHaskellDepends = [
+    aeson ansi-wl-pprint array async base boxes bytestring cassava
+    containers data-default Decimal deepseq directory edit-distance
+    file-embed filepath formatting hashable haskeline hint hledger
+    hledger-lib lens lifted-base ListLike megaparsec MissingH
+    monad-control mtl optparse-applicative parsec process regex-compat
+    regex-tdfa regex-tdfa-text safe semigroups split strict temporary
+    text time transformers unordered-containers vector yaml
+  ];
+  homepage = "http://johannesgerer.com/buchhaltung";
+  description = "Automates most of your plain text accounting data entry in ledger format";
+  license = stdenv.lib.licenses.mit;
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,12 @@
+let
+  config = {
+    packageOverrides = pkgs: rec {
+      haskellPackages = pkgs.haskellPackages.override {
+        overrides = haskellPackagesNew: haskellPackagesOld: rec {
+          buchhaltung = haskellPackagesNew.callPackage ./default.nix { };
+        };
+      };
+    };
+  };
+  pkgs = import <nixpkgs> { inherit config; };
+in { buchhaltung = pkgs.haskellPackages.buchhaltung; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./release.nix).buchhaltung.env

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,5 @@
-# resolver: nightly-2018-10-01
-resolver: lts-12.11
+resolver: lts-14.15
+
+extra-deps:
+  - hledger-lib-1.15.2
+  - hledger-1.15.2


### PR DESCRIPTION
This commit should fix incompatibilities with aqbanking 5.99.44.0, see #40.

Note that I build using Nix; I personally did not get the old stack build to work—thus the hlegder-lib version bump which I addressed in PR #47 .